### PR TITLE
fix: moved symfony/stimulus-bundle and symfony/webpack-encore-bundle …

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install Dependencies
         run: composer install --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
+      - name: Install Suggested Dependencies
+        run: composer require symfony/stimulus-bundle symfony/webpack-encore-bundle
       - name: Check Code Styles
         run: vendor/bin/ecs
       - name: Execute tests (Unit and Feature tests) via PHPUnit

--- a/composer.json
+++ b/composer.json
@@ -26,9 +26,7 @@
         "symfony/event-dispatcher": "^7.1|^6.4",
         "symfony/security-bundle":  "^7.1|^6.4",
         "symfony/framework-bundle": "^7.1|^6.4",
-        "symfony/process": "^7.1|^6.4",
-        "symfony/webpack-encore-bundle": "^1.14|^2.1",
-        "symfony/stimulus-bundle": "^2.16"
+        "symfony/process": "^7.1|^6.4"
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "^2.5",
@@ -54,6 +52,10 @@
         "zenstruck/console-test": "^v1.3.0",
         "zenstruck/browser": "^1.2",
         "phpstan/phpstan": "^1.12"
+    },
+    "suggest": {
+        "symfony/stimulus-bundle": "^2.16",
+        "symfony/webpack-encore-bundle": "^1.14|^2.1"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Browser/ControllerTest.php
+++ b/tests/Browser/ControllerTest.php
@@ -25,7 +25,7 @@ class ControllerTest extends KernelTestCase
     public function testShow(): void
     {
         $this->browser()
-            ->visit('/show/'.DemoCron::class)
+            ->visit('/show/'.urlencode(DemoCron::class))
             ->assertSuccessful()
         ;
     }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,6 +8,6 @@ require \dirname(__DIR__).'/vendor/autoload.php';
 
 (new Filesystem())->remove(__DIR__.'/../var');
 
-shell_exec('tests/App/bin/console doctrine:database:create --if-not-exists -n --env=test');
-shell_exec('tests/App/bin/console doctrine:schema:drop --full-database --force --env=test');
-shell_exec('tests/App/bin/console doctrine:schema:update --force --env=test');
+shell_exec('tests/App/bin/console doctrine:database:drop --if-exists --force -n --env=test');
+shell_exec('tests/App/bin/console doctrine:database:create -n --env=test');
+shell_exec('tests/App/bin/console doctrine:schema:create --env=test');


### PR DESCRIPTION
The packages `symfony/stimulus-bundle` and `symfony/webpack-encore-bundle` are not required and should be moved to suggest, because they are not necessary and only for the frontend of this bundle.