### PR TITLE
fix: Implicitly marking parameter $previous as nullable is deprecated

### DIFF
--- a/src/Exception/CronJobNotFoundException.php
+++ b/src/Exception/CronJobNotFoundException.php
@@ -31,7 +31,7 @@ namespace whatwedo\CronBundle\Exception;
 
 class CronJobNotFoundException extends CronException
 {
-    public function __construct(string $class, int $code = 0, \Throwable $previous = null)
+    public function __construct(string $class, int $code = 0, ?\Throwable $previous = null)
     {
         parent::__construct(sprintf('Cron job with class %s not found', $class), $code, $previous);
     }

--- a/src/Exception/MaxRuntimeReachedException.php
+++ b/src/Exception/MaxRuntimeReachedException.php
@@ -33,7 +33,7 @@ use whatwedo\CronBundle\Entity\Execution;
 
 class MaxRuntimeReachedException extends CronException
 {
-    public function __construct(Execution $execution, int $code = 0, \Throwable $previous = null)
+    public function __construct(Execution $execution, int $code = 0, ?\Throwable $previous = null)
     {
         parent::__construct(sprintf('Execution %s reached max runtime', $execution), $code, $previous);
     }


### PR DESCRIPTION
Refs: #19